### PR TITLE
Grpc metadata

### DIFF
--- a/grpc-bus.proto.js
+++ b/grpc-bus.proto.js
@@ -1,145 +1,152 @@
-module.exports = "syntax=\"proto3\";\n" +
-"package grpcbus;\n" +
-"\n" +
-"// Wrapper for a message from client\n" +
-"message GBClientMessage {\n" +
-"  // Service management\n" +
-"  GBCreateService service_create = 1;\n" +
-"  GBReleaseService service_release = 2;\n" +
-"\n" +
-"  // Call management\n" +
-"  GBCreateCall call_create = 3;\n" +
-"  // Terminates a call\n" +
-"  GBCallEnd    call_end    = 4;\n" +
-"  GBSendCall   call_send   = 5;\n" +
-"}\n" +
-"\n" +
-"message GBServerMessage {\n" +
-"  // service management responses\n" +
-"  GBCreateServiceResult service_create = 1;\n" +
-"  GBReleaseServiceResult service_release = 2;\n" +
-"\n" +
-"  // Call management\n" +
-"  GBCreateCallResult call_create = 3;\n" +
-"  GBCallEvent         call_event = 4;\n" +
-"  GBCallEnded         call_ended = 5;\n" +
-"}\n" +
-"\n" +
-"// Information about a service\n" +
-"message GBServiceInfo {\n" +
-"  // Endpoint\n" +
-"  string endpoint = 1;\n" +
-"  // Fully qualified service identifier\n" +
-"  string service_id = 2;\n" +
-"  // TODO: figure out how to serialize credentials\n" +
-"}\n" +
-"\n" +
-"// Initialize a new Service.\n" +
-"message GBCreateService {\n" +
-"  // ID of the service, client-generated, unique.\n" +
-"  int32 service_id = 1;\n" +
-"  GBServiceInfo service_info = 2;\n" +
-"}\n" +
-"\n" +
-"// Release an existing / pending Service.\n" +
-"message GBReleaseService {\n" +
-"  int32 service_id = 1;\n" +
-"}\n" +
-"\n" +
-"message GBCallInfo {\n" +
-"  string method_id = 1;\n" +
-"  bytes bin_argument = 2;\n" +
-"}\n" +
-"\n" +
-"// Create a call\n" +
-"message GBCreateCall {\n" +
-"  int32 service_id = 1;\n" +
-"  int32 call_id = 2;\n" +
-"  // Info\n" +
-"  GBCallInfo info = 3;\n" +
-"}\n" +
-"\n" +
-"// When the call is ended\n" +
-"message GBCallEnded {\n" +
-"  int32 call_id = 1;\n" +
-"  int32 service_id = 2;\n" +
-"}\n" +
-"\n" +
-"// End the call\n" +
-"message GBEndCall {\n" +
-"  int32 call_id = 1;\n" +
-"  int32 service_id = 2;\n" +
-"}\n" +
-"\n" +
-"// Send a message on a streaming call\n" +
-"message GBSendCall {\n" +
-"  int32 call_id = 1;\n" +
-"  int32 service_id = 2;\n" +
-"  bytes bin_data = 3;\n" +
-"  // Do we want to just send end() over a streaming call?\n" +
-"  bool is_end = 4;\n" +
-"}\n" +
-"\n" +
-"// Result of attempting to create a service\n" +
-"message GBCreateServiceResult {\n" +
-"  // ID of service, client-generated, unique\n" +
-"  int32 service_id = 1;\n" +
-"  // Result\n" +
-"  ECreateServiceResult result = 2;\n" +
-"  // Error details\n" +
-"  string error_details = 3;\n" +
-"\n" +
-"  enum ECreateServiceResult {\n" +
-"    // Success\n" +
-"    SUCCESS = 0;\n" +
-"    // Invalid service ID, retry with a new one.\n" +
-"    INVALID_ID = 1;\n" +
-"    // GRPC internal error constructing the service.\n" +
-"    GRPC_ERROR = 2;\n" +
-"  }\n" +
-"}\n" +
-"\n" +
-"// When the server releases a service\n" +
-"message GBReleaseServiceResult {\n" +
-"  int32 service_id = 1;\n" +
-"}\n" +
-"\n" +
-"// Result of creating a call.\n" +
-"// This is sent immediately after starting call.\n" +
-"message GBCreateCallResult {\n" +
-"  int32 call_id = 1;\n" +
-"  int32 service_id = 4;\n" +
-"\n" +
-"  // Result\n" +
-"  ECreateCallResult result = 2;\n" +
-"  string error_details = 3;\n" +
-"\n" +
-"  enum ECreateCallResult {\n" +
-"    // Success\n" +
-"    SUCCESS = 0;\n" +
-"    // Invalid call ID, retry with a new one.\n" +
-"    INVALID_ID = 1;\n" +
-"    // GRPC internal error initializing the call\n" +
-"    GRPC_ERROR = 2;\n" +
-"  }\n" +
-"}\n" +
-"\n" +
-"// Received message during streaming call.\n" +
-"message GBCallEvent {\n" +
-"  // Call ID\n" +
-"  int32 call_id = 1;\n" +
-"  // Service ID\n" +
-"  int32 service_id = 4;\n" +
-"  // Event ID\n" +
-"  string event = 2;\n" +
-"  // JSON data.\n" +
-"  string json_data = 3;\n" +
-"  // Binary data\n" +
-"  bytes bin_data = 5;\n" +
-"}\n" +
-"\n" +
-"// Terminate a call\n" +
-"message GBCallEnd {\n" +
-"  int32 call_id = 1;\n" +
-"  int32 service_id = 2;\n" +
-"}";
+module.exports = "syntax=\"proto3\";\n"+
+"package grpcbus;\n"+
+"\n"+
+"// Wrapper for a message from client\n"+
+"message GBClientMessage {\n"+
+"  // Service management\n"+
+"  GBCreateService service_create = 1;\n"+
+"  GBReleaseService service_release = 2;\n"+
+"\n"+
+"  // Call management\n"+
+"  GBCreateCall call_create = 3;\n"+
+"  // Terminates a call\n"+
+"  GBCallEnd    call_end    = 4;\n"+
+"  GBSendCall   call_send   = 5;\n"+
+"}\n"+
+"\n"+
+"message GBServerMessage {\n"+
+"  // service management responses\n"+
+"  GBCreateServiceResult service_create = 1;\n"+
+"  GBReleaseServiceResult service_release = 2;\n"+
+"\n"+
+"  // Call management\n"+
+"  GBCreateCallResult call_create = 3;\n"+
+"  GBCallEvent         call_event = 4;\n"+
+"  GBCallEnded         call_ended = 5;\n"+
+"}\n"+
+"\n"+
+"// Information about a service\n"+
+"message GBServiceInfo {\n"+
+"  // Endpoint\n"+
+"  string endpoint = 1;\n"+
+"  // Fully qualified service identifier\n"+
+"  string service_id = 2;\n"+
+"  // TODO: figure out how to serialize credentials\n"+
+"}\n"+
+"\n"+
+"// Initialize a new Service.\n"+
+"message GBCreateService {\n"+
+"  // ID of the service, client-generated, unique.\n"+
+"  int32 service_id = 1;\n"+
+"  GBServiceInfo service_info = 2;\n"+
+"}\n"+
+"\n"+
+"// Release an existing / pending Service.\n"+
+"message GBReleaseService {\n"+
+"  int32 service_id = 1;\n"+
+"}\n"+
+"\n"+
+"message GBMetadataValues {\n"+
+"  repeated string values = 1;\n"+
+"}\n"+
+"\n"+
+"message GBCallInfo {\n"+
+"  string method_id = 1;\n"+
+"  bytes bin_argument = 2;\n"+
+"  // Meta is a map from string to []string\n"+
+"  // e.g: https://godoc.org/google.golang.org/grpc/metadata#MD\n"+
+"  map<string, GBMetadataValues> metadata = 3;\n"+
+"}\n"+
+"\n"+
+"// Create a call\n"+
+"message GBCreateCall {\n"+
+"  int32 service_id = 1;\n"+
+"  int32 call_id = 2;\n"+
+"  // Info\n"+
+"  GBCallInfo info = 3;\n"+
+"}\n"+
+"\n"+
+"// When the call is ended\n"+
+"message GBCallEnded {\n"+
+"  int32 call_id = 1;\n"+
+"  int32 service_id = 2;\n"+
+"}\n"+
+"\n"+
+"// End the call\n"+
+"message GBEndCall {\n"+
+"  int32 call_id = 1;\n"+
+"  int32 service_id = 2;\n"+
+"}\n"+
+"\n"+
+"// Send a message on a streaming call\n"+
+"message GBSendCall {\n"+
+"  int32 call_id = 1;\n"+
+"  int32 service_id = 2;\n"+
+"  bytes bin_data = 3;\n"+
+"  // Do we want to just send end() over a streaming call?\n"+
+"  bool is_end = 4;\n"+
+"}\n"+
+"\n"+
+"// Result of attempting to create a service\n"+
+"message GBCreateServiceResult {\n"+
+"  // ID of service, client-generated, unique\n"+
+"  int32 service_id = 1;\n"+
+"  // Result\n"+
+"  ECreateServiceResult result = 2;\n"+
+"  // Error details\n"+
+"  string error_details = 3;\n"+
+"\n"+
+"  enum ECreateServiceResult {\n"+
+"    // Success\n"+
+"    SUCCESS = 0;\n"+
+"    // Invalid service ID, retry with a new one.\n"+
+"    INVALID_ID = 1;\n"+
+"    // GRPC internal error constructing the service.\n"+
+"    GRPC_ERROR = 2;\n"+
+"  }\n"+
+"}\n"+
+"\n"+
+"// When the server releases a service\n"+
+"message GBReleaseServiceResult {\n"+
+"  int32 service_id = 1;\n"+
+"}\n"+
+"\n"+
+"// Result of creating a call.\n"+
+"// This is sent immediately after starting call.\n"+
+"message GBCreateCallResult {\n"+
+"  int32 call_id = 1;\n"+
+"  int32 service_id = 4;\n"+
+"\n"+
+"  // Result\n"+
+"  ECreateCallResult result = 2;\n"+
+"  string error_details = 3;\n"+
+"\n"+
+"  enum ECreateCallResult {\n"+
+"    // Success\n"+
+"    SUCCESS = 0;\n"+
+"    // Invalid call ID, retry with a new one.\n"+
+"    INVALID_ID = 1;\n"+
+"    // GRPC internal error initializing the call\n"+
+"    GRPC_ERROR = 2;\n"+
+"  }\n"+
+"}\n"+
+"\n"+
+"// Received message during streaming call.\n"+
+"message GBCallEvent {\n"+
+"  // Call ID\n"+
+"  int32 call_id = 1;\n"+
+"  // Service ID\n"+
+"  int32 service_id = 4;\n"+
+"  // Event ID\n"+
+"  string event = 2;\n"+
+"  // JSON data.\n"+
+"  string json_data = 3;\n"+
+"  // Binary data\n"+
+"  bytes bin_data = 5;\n"+
+"}\n"+
+"\n"+
+"// Terminate a call\n"+
+"message GBCallEnd {\n"+
+"  int32 call_id = 1;\n"+
+"  int32 service_id = 2;\n"+
+"}\n";

--- a/grpc-bus.proto.json
+++ b/grpc-bus.proto.json
@@ -1,8 +1,10 @@
 {
     "package": "grpcbus",
+    "syntax": "proto2",
     "messages": [
         {
             "name": "GBClientMessage",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -38,6 +40,7 @@
         },
         {
             "name": "GBServerMessage",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -73,6 +76,7 @@
         },
         {
             "name": "GBServiceInfo",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -90,6 +94,7 @@
         },
         {
             "name": "GBCreateService",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -107,6 +112,7 @@
         },
         {
             "name": "GBReleaseService",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -117,7 +123,20 @@
             ]
         },
         {
+            "name": "GBMetadataValues",
+            "syntax": "proto3",
+            "fields": [
+                {
+                    "rule": "repeated",
+                    "type": "string",
+                    "name": "values",
+                    "id": 1
+                }
+            ]
+        },
+        {
             "name": "GBCallInfo",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -130,11 +149,19 @@
                     "type": "bytes",
                     "name": "bin_argument",
                     "id": 2
+                },
+                {
+                    "rule": "map",
+                    "type": "GBMetadataValues",
+                    "keytype": "string",
+                    "name": "metadata",
+                    "id": 3
                 }
             ]
         },
         {
             "name": "GBCreateCall",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -158,6 +185,7 @@
         },
         {
             "name": "GBCallEnded",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -175,6 +203,7 @@
         },
         {
             "name": "GBEndCall",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -192,6 +221,7 @@
         },
         {
             "name": "GBSendCall",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -221,6 +251,7 @@
         },
         {
             "name": "GBCreateServiceResult",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -244,6 +275,7 @@
             "enums": [
                 {
                     "name": "ECreateServiceResult",
+                    "syntax": "proto3",
                     "values": [
                         {
                             "name": "SUCCESS",
@@ -263,6 +295,7 @@
         },
         {
             "name": "GBReleaseServiceResult",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -274,6 +307,7 @@
         },
         {
             "name": "GBCreateCallResult",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -303,6 +337,7 @@
             "enums": [
                 {
                     "name": "ECreateCallResult",
+                    "syntax": "proto3",
                     "values": [
                         {
                             "name": "SUCCESS",
@@ -322,6 +357,7 @@
         },
         {
             "name": "GBCallEvent",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -357,6 +393,7 @@
         },
         {
             "name": "GBCallEnd",
+            "syntax": "proto3",
             "fields": [
                 {
                     "rule": "optional",
@@ -372,5 +409,6 @@
                 }
             ]
         }
-    ]
+    ],
+    "isNamespace": true
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This client library connects a browser's JavaScript context to standard GRPC service(s) via a WebSocket Proxy Server",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "update-proto": "node ./scripts/proto_to_js.js > grpc-bus.proto.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "protobufjs": "^5.0.2",
     "rsvp": "^3.3.3",
     "universal-websocket-client": "^1.0.1"
+  },
+  "devDependencies": {
+    "line-reader": "^0.4.0"
   }
 }

--- a/scripts/proto_to_js.js
+++ b/scripts/proto_to_js.js
@@ -1,0 +1,15 @@
+var lines = [];
+var lineReader = require('line-reader');
+
+lineReader.eachLine('node_modules/grpc-bus/proto/grpc-bus.proto', function(line, last) {
+    var escaped = "\"";
+    escaped += line.replace(/"/g, '\\"')
+    escaped += "\\n\"";
+    lines.push(escaped);
+  // do whatever you want with line...
+  if(last){
+      var fullText = "module.exports = " + lines.join("+\n") + ";";
+      console.log(fullText);
+    // or check if it's the last one
+  }
+});


### PR DESCRIPTION
Update the proto files so that the client can pass along the metadata.

Also added a `update-proto` package.json script so that we can regenerate the goofy JS string version of the proto definitions (needed to detect zero / non null values).